### PR TITLE
Respect optional cache flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ python -m lm_eval \
 ```
 
 - 평가 데이터는 `data/<benchmark>/<subject>.csv` 아래에 배치해야 하며, 결과는 `results`에 저장됩니다.
-- `--cache` 디렉터리를 지정하면 `<sanitized_model>_<timestamp>.json` 형식의 단일 캐시 파일이 생성되어 모든 벤치마크에서 공유됩니다. 지정하지 않으면 `.cache`가 사용됩니다.
+- `--cache` 디렉터리를 지정하면 `<sanitized_model>_<timestamp>.json` 형식의 단일 캐시 파일이 생성되어 모든 벤치마크에서 공유됩니다. 지정하지 않으면 `.cache` 아래에 현재 실행을 위한 새 캐시 파일이 생성됩니다.
 - 서버 불안정 등으로 평가가 중단된 경우, 동일한 디렉터리를 `--cache`로 지정하면 기존 캐시를 이어서 사용할 수 있습니다.
 - 결과에는 `response`와 `parsed_response`가 저장됩니다.
 

--- a/lm_eval.py
+++ b/lm_eval.py
@@ -234,18 +234,22 @@ def main() -> None:
     args = parser.parse_args()
 
     sanitized_model = args.model.replace("/", "__")
+    timestamp = datetime.now().strftime("%y%m%d-%H%M%S")
     cache_dir = Path(args.cache) if args.cache else Path(".cache")
     cache_dir.mkdir(parents=True, exist_ok=True)
-    existing = sorted(cache_dir.glob(f"{sanitized_model}_*.json"))
-    timestamp = datetime.now().strftime("%y%m%d-%H%M%S")
-    if existing:
-        cache_file = existing[-1]
-        parts = cache_file.stem.split("_")
-        if len(parts) > 1:
-            timestamp = parts[-1]
+    if args.cache:
+        existing = sorted(cache_dir.glob(f"{sanitized_model}_*.json"))
+        if existing:
+            cache_file = existing[-1]
+            parts = cache_file.stem.split("_")
+            if len(parts) > 1:
+                timestamp = parts[-1]
+        else:
+            cache_file = cache_dir / f"{sanitized_model}_{timestamp}.json"
+        cache = load_cache(cache_file)
     else:
         cache_file = cache_dir / f"{sanitized_model}_{timestamp}.json"
-    cache = load_cache(cache_file)
+        cache = {}
 
     args.sanitized_model = sanitized_model
     args.timestamp = timestamp


### PR DESCRIPTION
## Summary
- Only load cache when `--cache` flag is provided and create a fresh cache file for runs without it
- Document new cache behavior in README

## Testing
- `python -m py_compile lm_eval.py`
- `python lm_eval.py --help`


------
https://chatgpt.com/codex/tasks/task_e_689da22237c483328b4d9c971c739ac6